### PR TITLE
wminput: Add command line argument to specify uinput device name

### DIFF
--- a/wminput/conf.c
+++ b/wminput/conf.c
@@ -42,11 +42,17 @@ struct conf *cur_conf;
 struct plugin *get_plugin(struct conf *conf, const char *name);
 
 int conf_load(struct conf *conf, const char *conf_name,
-              char *config_search_dirs[], char *plugin_search_dirs[])
+              char *config_search_dirs[], char *plugin_search_dirs[],
+              const char *dev_name)
 {
 	conf_init(conf);
 	cur_conf = conf;
 
+	if (dev_name != NULL)
+	{
+		strncpy(cur_conf->dev.name, dev_name, sizeof(cur_conf->dev.name));
+	}
+	
 	cur_conf->config_search_dirs = config_search_dirs;
 	cur_conf->plugin_search_dirs = plugin_search_dirs;
 	if (!(yyin = conf_push_config(cur_conf, conf_name, NULL))) {

--- a/wminput/conf.h
+++ b/wminput/conf.h
@@ -170,7 +170,8 @@ struct uinput_listen_data {
 };
 
 int conf_load(struct conf *conf, const char *conf_name,
-              char *config_search_dirs[], char *plugin_search_dirs[]);
+              char *config_search_dirs[], char *plugin_search_dirs[],
+              const char *dev_name);
 int conf_unload(struct conf *conf);
 
 int conf_ff(struct conf *conf, unsigned char enabled);

--- a/wminput/main.c
+++ b/wminput/main.c
@@ -73,6 +73,7 @@ void print_usage(void)
 	printf("\t-q, --quiet\t\tReduce output to errors\n");
 	printf("\t-r, --reconnect [wait]\tAutomatically try reconnect after wiimote disconnect.\n");
 	printf("\t-w, --wait\t\tWait indefinitely for wiimote to connect.\n");
+	printf("\t-n, --name [name]\tName for the created input device.\n");
 }
 
 void cwiid_err_connect(struct wiimote *wiimote, const char *str, va_list ap)
@@ -92,6 +93,7 @@ int main(int argc, char *argv[])
 	char home_config_dir[HOME_DIR_LEN];
 	char home_plugin_dir[HOME_DIR_LEN];
 	char *tmp;
+	const char *dev_name = NULL;
 	int c, i;
 	char *str_addr;
 	bdaddr_t bdaddr, current_bdaddr;
@@ -114,10 +116,11 @@ int main(int argc, char *argv[])
 			{"quiet", 0, 0, 'q'},
 			{"reconnect", 2, 0, 'r'},
 			{"wait", 0, 0, 'w'},
+			{"name", 1, 0, 'n'},
 			{0, 0, 0, 0}
 		};
 
-		c = getopt_long (argc, argv, "hvc:dqr::w", long_options, &option_index);
+		c = getopt_long (argc, argv, "hvc:dqr::wn:", long_options, &option_index);
 
 		if (c == -1) {
 			break;
@@ -155,6 +158,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'w':
 			wait_forever = 1;
+			break;
+		case 'n':
+			dev_name = optarg;
 			break;
 		case '?':
 			printf("Try `wminput --help` for more information\n");
@@ -195,7 +201,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (conf_load(&conf, config_filename, config_search_dirs,
-	  plugin_search_dirs)) {
+	  plugin_search_dirs, dev_name)) {
 		return -1;
 	}
 


### PR DESCRIPTION
For the uinput device the hard coded name "Nintendo Wiimote" is used.

A recent Xserver (udev support) will use this name for the X input device name, if we add the device and a X session is already running.

So I added a command line argument to specify the name for the uinput device.
