### PR TITLE
Fix for issue #18.

### DIFF
--- a/wminput/conf.c
+++ b/wminput/conf.c
@@ -159,8 +159,8 @@ int conf_axis(struct conf *conf, int axis, __u16 axis_type, __u16 action,
 	case CONF_NC_AXIS_STICK_Y:
 		conf->rpt_mode_flags |= CWIID_RPT_NUNCHUK;
 		if (axis_type == EV_ABS) {
-			conf->dev.absmax[action] = 0xFF;
-			conf->dev.absmin[action] = 0;
+			conf->dev.absmax[action] = 0xFF/2.0;
+			conf->dev.absmin[action] = -0xFF/2.0;
 			conf->dev.absfuzz[action] = 0;
 			conf->dev.absflat[action] = 0;
 		}
@@ -179,8 +179,8 @@ int conf_axis(struct conf *conf, int axis, __u16 axis_type, __u16 action,
 	case CONF_CC_AXIS_L_STICK_Y:
 		conf->rpt_mode_flags |= CWIID_RPT_CLASSIC;
 		if (axis_type == EV_ABS) {
-			conf->dev.absmax[action] = CWIID_CLASSIC_L_STICK_MAX;
-			conf->dev.absmin[action] = 0;
+			conf->dev.absmax[action] = CWIID_CLASSIC_L_STICK_MAX/2.0;
+			conf->dev.absmin[action] = -CWIID_CLASSIC_L_STICK_MAX/2.0;
 			conf->dev.absfuzz[action] = 0;
 			conf->dev.absflat[action] = 0;
 		}
@@ -189,8 +189,8 @@ int conf_axis(struct conf *conf, int axis, __u16 axis_type, __u16 action,
 	case CONF_CC_AXIS_R_STICK_Y:
 		conf->rpt_mode_flags |= CWIID_RPT_CLASSIC;
 		if (axis_type == EV_ABS) {
-			conf->dev.absmax[action] = CWIID_CLASSIC_R_STICK_MAX;
-			conf->dev.absmin[action] = 0;
+			conf->dev.absmax[action] = CWIID_CLASSIC_R_STICK_MAX/2.0;
+			conf->dev.absmin[action] = -CWIID_CLASSIC_R_STICK_MAX/2.0;
 			conf->dev.absfuzz[action] = 0;
 			conf->dev.absflat[action] = 0;
 		}

--- a/wminput/main.c
+++ b/wminput/main.c
@@ -510,9 +510,9 @@ void process_nunchuk_mesg(struct cwiid_nunchuk_mesg *mesg)
 
 	/* Nunchuk.Stick.X */
 	if (conf.amap[CONF_NC_AXIS_STICK_X].active) {
-		axis_value = mesg->stick[CWIID_X];
+		axis_value = mesg->stick[CWIID_X]-0xFF/2.0;
 		if (conf.amap[CONF_NC_AXIS_STICK_X].flags & CONF_INVERT) {
-			axis_value = 0xFF - axis_value;
+			axis_value = -axis_value;
 		}
 		send_event(&conf, conf.amap[CONF_NC_AXIS_STICK_X].axis_type,
 		           conf.amap[CONF_NC_AXIS_STICK_X].action, axis_value);
@@ -520,9 +520,9 @@ void process_nunchuk_mesg(struct cwiid_nunchuk_mesg *mesg)
 
 	/* Nunchuk.Stick.Y */
 	if (conf.amap[CONF_NC_AXIS_STICK_Y].active) {
-		axis_value = mesg->stick[CWIID_Y];
+		axis_value = mesg->stick[CWIID_Y]-0xFF/2.0;
 		if (conf.amap[CONF_NC_AXIS_STICK_Y].flags & CONF_INVERT) {
-			axis_value = 0xFF - axis_value;
+			axis_value = axis_value;
 		}
 		send_event(&conf, conf.amap[CONF_NC_AXIS_STICK_Y].axis_type,
 		           conf.amap[CONF_NC_AXIS_STICK_Y].action, axis_value);
@@ -585,9 +585,9 @@ void process_classic_mesg(struct cwiid_classic_mesg *mesg)
 
 	/* Classic.LStick.X */
 	if (conf.amap[CONF_CC_AXIS_L_STICK_X].active) {
-		axis_value = mesg->l_stick[CWIID_X];
+		axis_value = mesg->l_stick[CWIID_X]-CWIID_CLASSIC_L_STICK_MAX/2.0;
 		if (conf.amap[CONF_CC_AXIS_L_STICK_X].flags & CONF_INVERT) {
-			axis_value = CWIID_CLASSIC_L_STICK_MAX - axis_value;
+			axis_value = -axis_value;
 		}
 		send_event(&conf, conf.amap[CONF_CC_AXIS_L_STICK_X].axis_type,
 		           conf.amap[CONF_CC_AXIS_L_STICK_X].action, axis_value);
@@ -595,9 +595,9 @@ void process_classic_mesg(struct cwiid_classic_mesg *mesg)
 
 	/* Classic.LStick.Y */
 	if (conf.amap[CONF_CC_AXIS_L_STICK_Y].active) {
-		axis_value = mesg->l_stick[CWIID_Y];
+		axis_value = mesg->l_stick[CWIID_Y]-CWIID_CLASSIC_L_STICK_MAX/2.0;
 		if (conf.amap[CONF_CC_AXIS_L_STICK_Y].flags & CONF_INVERT) {
-			axis_value = CWIID_CLASSIC_L_STICK_MAX - axis_value;
+			axis_value = -axis_value;
 		}
 		send_event(&conf, conf.amap[CONF_CC_AXIS_L_STICK_Y].axis_type,
 		           conf.amap[CONF_CC_AXIS_L_STICK_Y].action, axis_value);
@@ -605,9 +605,9 @@ void process_classic_mesg(struct cwiid_classic_mesg *mesg)
 
 	/* Classic.RStick.X */
 	if (conf.amap[CONF_CC_AXIS_R_STICK_X].active) {
-		axis_value = mesg->r_stick[CWIID_X];
+		axis_value = mesg->r_stick[CWIID_X]-CWIID_CLASSIC_R_STICK_MAX/2.0;
 		if (conf.amap[CONF_CC_AXIS_R_STICK_X].flags & CONF_INVERT) {
-			axis_value = CWIID_CLASSIC_R_STICK_MAX - axis_value;
+			axis_value = -axis_value;
 		}
 		send_event(&conf, conf.amap[CONF_CC_AXIS_R_STICK_X].axis_type,
 		           conf.amap[CONF_CC_AXIS_R_STICK_X].action, axis_value);
@@ -615,9 +615,9 @@ void process_classic_mesg(struct cwiid_classic_mesg *mesg)
 
 	/* Classic.RStick.Y */
 	if (conf.amap[CONF_CC_AXIS_R_STICK_Y].active) {
-		axis_value = mesg->r_stick[CWIID_Y];
+		axis_value = mesg->r_stick[CWIID_Y]-CWIID_CLASSIC_R_STICK_MAX/2.0;
 		if (conf.amap[CONF_CC_AXIS_R_STICK_Y].flags & CONF_INVERT) {
-			axis_value = CWIID_CLASSIC_R_STICK_MAX - axis_value;
+			axis_value = -axis_value;
 		}
 		send_event(&conf, conf.amap[CONF_CC_AXIS_R_STICK_Y].axis_type,
 		           conf.amap[CONF_CC_AXIS_R_STICK_Y].action, axis_value);


### PR DESCRIPTION
The coordinates returned by the joystick interface were defined in such a way, that the lowest possible value was zero. Applications nevertheless expect zero to represent the neutral position, not the lowest one. This patch fixes this issue.
